### PR TITLE
Compatibility with Django 2.x and Django 3.0

### DIFF
--- a/djangomaat/handlers.py
+++ b/djangomaat/handlers.py
@@ -3,7 +3,20 @@ from __future__ import unicode_literals
 import inspect
 from time import time
 
-from django.utils.encoding import python_2_unicode_compatible
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    # Django > 2
+    def python_2_unicode_compatible(klass):
+        """
+        A decorator that defines __unicode__ and __str__ methods under Python 2.
+        Under Python 3 it does nothing.
+
+        To support Python 2 and 3 with a single code base, define a __str__ method
+        returning text and apply this decorator to the class.
+        """
+        return klass
+        
 from django.contrib.contenttypes.models import ContentType
 try:
     from django.db.transaction import atomic
@@ -13,7 +26,6 @@ except ImportError:
 from djangomaat.models import MaatRanking
 from djangomaat.exceptions import ManagerDoesNotExist, TypologyNotImplemented
 from djangomaat.settings import FLUSH_BATCH_SIZE
-from django.utils.encoding import python_2_unicode_compatible
 
 GETTER_PREFIX = 'get_pk_list_for_'
 

--- a/djangomaat/migrations/0001_initial.py
+++ b/djangomaat/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-
+import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('typology', models.CharField(max_length=255, db_index=True)),
                 ('usable', models.BooleanField(default=False)),
                 ('position', models.PositiveIntegerField(default=0)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType')),
             ],
             options={
             },

--- a/djangomaat/models.py
+++ b/djangomaat/models.py
@@ -12,7 +12,7 @@ from django.utils.encoding import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class MaatRanking(models.Model):
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField(db_index=True)
     content_object = GenericForeignKey('content_type', 'object_id')
 

--- a/djangomaat/models.py
+++ b/djangomaat/models.py
@@ -7,8 +7,20 @@ except ImportError:
     # Django < 1.9
     from django.contrib.contenttypes.generic import GenericForeignKey
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    # Django > 2
+    def python_2_unicode_compatible(klass):
+        """
+        A decorator that defines __unicode__ and __str__ methods under Python 2.
+        Under Python 3 it does nothing.
+
+        To support Python 2 and 3 with a single code base, define a __str__ method
+        returning text and apply this decorator to the class.
+        """
+        return klass
 
 @python_2_unicode_compatible
 class MaatRanking(models.Model):

--- a/djangomaat/tests.py
+++ b/djangomaat/tests.py
@@ -3,7 +3,21 @@ import unittest
 
 from django.core.management import call_command
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    # Django > 2
+    def python_2_unicode_compatible(klass):
+        """
+        A decorator that defines __unicode__ and __str__ methods under Python 2.
+        Under Python 3 it does nothing.
+
+        To support Python 2 and 3 with a single code base, define a __str__ method
+        returning text and apply this decorator to the class.
+        """
+        return klass
+
 try:
     from django.contrib.contenttypes.fields import ReverseGenericManyToOneDescriptor as RGD
 except ImportError:

--- a/djangomaat/tests.py
+++ b/djangomaat/tests.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
-import unittest
 
+from django.test import TestCase
 from django.core.management import call_command
 from django.db import models
 
@@ -60,7 +60,7 @@ class MockLogger(object):
     def write(self, something):
         pass
 
-class ClientTest(unittest.TestCase):
+class ClientTest(TestCase):
 
     def setUp(self):
         self.h = TestMaatHandler(TestModel)

--- a/djangomaat/tests.py
+++ b/djangomaat/tests.py
@@ -27,7 +27,8 @@ except ImportError:
     except ImportError:
         # Django < 1.7
         from django.contrib.contenttypes.generic import ReverseGenericRelatedObjectsDescriptor as RGD
-from django.utils.six import StringIO
+
+from six import StringIO
 
 from djangomaat.register import maat
 from djangomaat.handlers import MaatHandler

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,4 +21,4 @@ MAAT_FLUSH_BATCH_SIZE = 100 # To avoid sqlite issues
 # This will prevent the tests from running the migrations that come with the app
 # otherwise the test models won't be created.
 # http://stackoverflow.com/questions/25161425/disable-migrations-when-running-unit-tests-in-django-1-7
-MIGRATION_MODULES = {'djangomaat': 'djangomaat.no_migrations_here'}
+MIGRATION_MODULES = {'djangomaat': None}

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,20 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35}-django18,
-    {py27,py34,py35}-django{19,110},
+    {py27,py33,py37}-django18,
+    {py27,py33,py37}-django{19,110},
+    {py33,py37}-django{20,30},
     coverage
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
 deps =
+    six
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django20: Django<3
+    django30: Django<4
 commands =
     django-admin.py test djangomaat
 setenv =
@@ -23,5 +27,6 @@ commands =
     coverage run --branch --include={toxinidir}/djangomaat/* --omit={toxinidir}/djangomaat/tests* {envbindir}/django-admin.py test djangomaat
     coveralls
 deps =
+    six
     coveralls
     Django>=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py{310,311}-django{32,42}
-            coverage
+envlist = py{312,313}-django{42,51,52}
+            ; coverage
 skip_missing_interpreters = True
 
 [testenv]
@@ -10,8 +10,9 @@ commands = {envbindir}/django-admin test --verbosity=2 djangomaat
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = tests.settings
-deps =  django32: Django>=3.2,<4.0
-        django42: Django>=4.2,<5.0
+deps =  django42: Django>=4.2,<5.0
+        django51: Django>=5.1,<5.2
+        django52: Django>=5.2,<6.0
         six
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,24 @@
 [tox]
-envlist =
-    ; {py27,py33}-django18,
-    {py27,py33,py37}-django{19,110,111},
-    {py33,py37}-django{20,30},
-    coverage
+envlist = py{310,311}-django{32,42}
+            coverage
+skip_missing_interpreters = True
 
 [testenv]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
-deps =
-    six
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<2
-    django20: Django<3
-    django30: Django<4
-commands =
-    django-admin.py test --verbosity=2 djangomaat
-setenv =
-    DJANGO_SETTINGS_MODULE = settings
-    PYTHONPATH = {toxinidir}/tests
 changedir = {toxinidir}/tests/
+commands = {envbindir}/django-admin test --verbosity=2 djangomaat
+setenv =
+    PYTHONPATH = {toxinidir}
+    DJANGO_SETTINGS_MODULE = tests.settings
+deps =  django32: Django>=3.2,<4.0
+        django42: Django>=4.2,<5.0
+        six
 
-[testenv:coverage]
-commands =
-    coverage run --branch --include={toxinidir}/djangomaat/* --omit={toxinidir}/djangomaat/tests* {envbindir}/django-admin.py test djangomaat
-    coveralls
-deps =
-    six
-    coveralls
-    Django>=1.11,<4
+
+; [testenv:coverage]
+; commands =
+;     coverage run --branch --include={toxinidir}/djangomaat/* --omit={toxinidir}/djangomaat/tests* {envbindir}/django-admin test djangomaat
+;     coveralls
+; deps =
+;     six
+;     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27,py33,py37}-django18,
-    {py27,py33,py37}-django{19,110},
+    ; {py27,py33}-django18,
+    {py27,py33,py37}-django{19,110,111},
     {py33,py37}-django{20,30},
     coverage
 
@@ -13,10 +13,11 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
     django20: Django<3
     django30: Django<4
 commands =
-    django-admin.py test djangomaat
+    django-admin.py test --verbosity=2 djangomaat
 setenv =
     DJANGO_SETTINGS_MODULE = settings
     PYTHONPATH = {toxinidir}/tests
@@ -29,4 +30,4 @@ commands =
 deps =
     six
     coveralls
-    Django>=1.10,<1.11
+    Django>=1.11,<4


### PR DESCRIPTION
Added six as a requirement because "django.utils.six" has been removed.